### PR TITLE
update formula for cabal-cache-1.0.0.1

### DIFF
--- a/Formula/cabal-cache.rb
+++ b/Formula/cabal-cache.rb
@@ -5,7 +5,7 @@ class CabalCache < Formula
 
   desc "CI configuration tool"
   homepage "https://github.com/haskell-works/cabal-cache"
-  url "https://github.com/haskell-works/cabal-cache/archive/v1.0.0.0.tar.gz"
+  url "https://github.com/haskell-works/cabal-cache/archive/v1.0.0.1.tar.gz"
   sha256 "ec1cf96935e5d69b9554270b11f13261ef7b0e890d32d9be8b6cb53af31f93a3"
   head "https://github.com/haskell-works/cabal-cache"
 
@@ -20,17 +20,17 @@ class CabalCache < Formula
   end
 
   bottle do
-    root_url "https://github.com/haskell-works/homebrew-haskell-works/releases/download/cabal-cache-1.0.0.0"
+    root_url "https://github.com/haskell-works/homebrew-haskell-works/releases/download/cabal-cache-1.0.0.1"
     cellar :any_skip_relocation
     rebuild 1
-    sha256 "2962040c149cdbec23e492245951cdb6c3d5c113aa5a648ec5f502901f32e328" => :mojave
+    sha256 "0ee131962af50b97bc90cb51500de18bf0769416c56c112948f9effd8d15911a" => :mojave
   end
 
   bottle do
-    root_url "https://github.com/haskell-works/homebrew-haskell-works/releases/download/cabal-cache-1.0.0.0"
+    root_url "https://github.com/haskell-works/homebrew-haskell-works/releases/download/cabal-cache-1.0.0.1"
     cellar :any_skip_relocation
     rebuild 1
-    sha256 "2962040c149cdbec23e492245951cdb6c3d5c113aa5a648ec5f502901f32e328" => :high_sierra
+    sha256 "0ee131962af50b97bc90cb51500de18bf0769416c56c112948f9effd8d15911a" => :high_sierra
   end
 
   test do


### PR DESCRIPTION
Tested locally:
* cp cabal-cache.rb /usr/local/Homebrew/Library/Taps/haskell-works/homebrew-haskell-works/Formula/cabal-cache.rb
* upgrade cabal-cache:
```
jwan@~/Start/atlas/haskell/homebrew-haskell-works/Formula (master) $ brew upgrade cabal-cache
Updating Homebrew...
==> Upgrading 1 outdated package:
haskell-works/haskell-works/cabal-cache 1.0.0.0 -> 1.0.0.1
==> Upgrading haskell-works/haskell-works/cabal-cache
==> Downloading https://github.com/haskell-works/homebrew-haskell-works/releases/download/cabal-cache-1.0.0.1/cabal-cache-1.0.0.1.mojave.bottle.1.tar.gz
Already downloaded: /Users/jwan/Library/Caches/Homebrew/downloads/3b5c45ccf03032b4d8242720d9b72bb33b364a3eb1620a28dc1518bc39b6b541--cabal-cache-1.0.0.1.mojave.bottle.1.tar.gz
==> Pouring cabal-cache-1.0.0.1.mojave.bottle.1.tar.gz
==> Caveats
Bash completion has been installed to:
  /usr/local/etc/bash_completion.d
==> Summary
🍺  /usr/local/Cellar/cabal-cache/1.0.0.1: 8 files, 9.5MB
Removing: /usr/local/Cellar/cabal-cache/1.0.0.0... (8 files, 9.4MB)
Removing: /Users/jwan/Library/Caches/Homebrew/cabal-cache--1.0.0.0.mojave.bottle.1.tar.gz... (2.4MB)
```
```
jwan@~/Start/atlas/haskell/homebrew-haskell-works/Formula (update-formula-for-cabal-cache-1.0.0.1) $ cabal-cache version
cabal-cache 1.0.0.1
```